### PR TITLE
AO-20176 - Fixed laravel 6 nosetest failure

### DIFF
--- a/6/vendor/facade/ignition/config/flare.php
+++ b/6/vendor/facade/ignition/config/flare.php
@@ -26,7 +26,7 @@ return [
 
     'reporting' => [
         'anonymize_ips' => true,
-        'collect_git_information' => true,
+        'collect_git_information' => false,
         'report_queries' => true,
         'maximum_number_of_collected_queries' => 200,
         'report_query_bindings' => true,


### PR DESCRIPTION
### Summary
Some Laravel 6 nose test cases are failing. 
After investigation, the `collect_git_information` is found `true`. `true` means to collect git information in every error log and it should be `false` by [default](https://github.com/facade/ignition/blob/main/config/flare.php). It causes the apache to fork many processes in order to keep its capacity and slowing down the test. As a result, the `get_event` of nosetest script cannot receive the expected events on time and causing test failure.

### Related issues
[AO-20176](https://swicloud.atlassian.net/browse/AO-20176)

### Reviewers
@cheempz 
@kuerbis-martin 